### PR TITLE
hopefully fixes bumpversion with build

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,15 @@
 [bumpversion]
 current_version = 0.0.1
+
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
+serialize = {major}.{minor}.{patch}
 commit = True
-tag = False
+tag = True
 
 [bumpversion:file:setup.py]
+search = version='{current_version}'
+replace = version='{new_version}'
+
 [bumpversion:file:conda-recipe/meta.yaml]
+search = version: {current_version}
+replace = version: {new_version}

--- a/conda-build-and-upload.sh
+++ b/conda-build-and-upload.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
 
+export BIOMETALIB_BUILD=$(git rev-list --count `git describe --tags --abbrev=0`..HEAD --count)
+
 conda build conda-recipe
 
-if [[ $TRAVIS_BRANCH = "master" && $TRAVIS_PULL_REQUEST = "false" ]]; then
-  conda install anaconda-client -y
-  anaconda \
-    -t $ANACONDA_TOKEN \
-    upload \
-    -u jfear \
-    --force \
-    $(conda build --output conda-recipe)
-fi
+#if [[ $TRAVIS_BRANCH = "master" && $TRAVIS_PULL_REQUEST = "false" ]]; then
+#  conda install anaconda-client -y
+#  anaconda \
+#    -t $ANACONDA_TOKEN \
+#    upload \
+#    -u jfear \
+#    --force \
+#    $(conda build --output conda-recipe)
+#fi

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -5,6 +5,9 @@ source:
   git_url: https://github.com/jfear/biometalib.git
   git_rev: master
 
+build:
+  number: {{ BIOMETALIB_BUILD }}
+
 requirements:
   build:
     - bumpversion ==0.5.3


### PR DESCRIPTION
I have been messing with the versioning framework using bumpversion. I was trying to force bumpversion to add build number to the conda recipe. However I realized that it is much easier to just count the number of commits from the last tag and use that as a build number.