### PR TITLE
Change MongoClient to connect.

### DIFF
--- a/biometalib/utils/initialize_biometa.py
+++ b/biometalib/utils/initialize_biometa.py
@@ -69,7 +69,7 @@ def arguments():
 
 
 def connect_mongo(host, port, db, u, p, auth_db):
-    client = MongoClient(host=host, port=port)
+    client = me.connect(host=host, port=port)
     if (u is not None) & (p is not None) & (auth_db is not None):
         client[auth_db].authenticate(u, p)
     return client


### PR DESCRIPTION
When adding CLI options I accidently changed the client to use pymongo
syntax instead of mongoengine syntax.